### PR TITLE
Edit post tags endpoint and some changes

### DIFF
--- a/src/api/controllers/stats.controller.js
+++ b/src/api/controllers/stats.controller.js
@@ -28,7 +28,7 @@ const buildQuery = (filter, req) => {
 
     // If the request has params, it is the username, append it.
     if (Object.keys(req.query).length !== 0) {
-      query = { ...query, 'moderation.moderatedBy': req.query.username };
+      query = { ...query, 'moderation.moderatedBy': req.query.author };
     }
 
     return query;
@@ -39,7 +39,7 @@ const buildQuery = (filter, req) => {
 
     // If the request has params, it is the username, append it.
     if (Object.keys(req.query).length !== 0) {
-      query = { ...query, 'moderation.moderatedBy': req.query.username };
+      query = { ...query, 'moderation.moderatedBy': req.query.author };
     }
 
     return query;
@@ -65,7 +65,7 @@ const buildQuery = (filter, req) => {
 
     // If the request has params, it is the username, append it.
     if (Object.keys(req.query).length !== 0) {
-      query = { ...query, 'moderation.moderatedBy': req.query.username };
+      query = { ...query, 'moderation.moderatedBy': req.query.author };
     }
 
     return query;

--- a/src/api/routes/v1/posts.route.js
+++ b/src/api/routes/v1/posts.route.js
@@ -185,6 +185,11 @@ router.route('/:author/:permlink/votes').get(validate(single), controller.getVot
  * @apiHeader  {String}   access_token      SC2 User's access token
  * @apiHeader  {String}   permlink          Permlink of the post
  * @apiHeader  {Array}    tags              Tags of the post
+ *
+ * @apiSuccess {Number}   status            http status response
+ * @apiSuccess {String}   message           http return message
+ *
+ * @apiError (Unauthorized 401) Unauthorized Only authenticated users can edit a post
  */
 router.route('/update').put(validate(update), sc2Middleware, controller.updateTags);
 

--- a/src/api/routes/v1/posts.route.js
+++ b/src/api/routes/v1/posts.route.js
@@ -4,7 +4,7 @@ const controller = require('../../controllers/posts.controller');
 const sc2Middleware = require('../../middlewares/sc2');
 const checkUserMiddleware = require('../../middlewares/username_exists');
 const isBannedMiddleware = require('../../middlewares/is_banned');
-const { create, single } = require('../../validations/post.validation');
+const { create, single, update } = require('../../validations/post.validation');
 
 const router = express.Router();
 
@@ -17,8 +17,9 @@ const router = express.Router();
  * @apiPermission user
  *
  * @apiHeader  {String}   access_token      SC2 User's access token
- *
- * @apiParam   {String}   permlink          Permlink of the post
+ * @apiHeader  {String}   permlink          Permlink of the post
+ * @apiHeader  {String}   category          Category of the post
+ * @apiHeader  {Array}    tags              Tags of the post
  *
  * @apiSuccess {Number}   status            http status response
  * @apiSuccess {String}   message           http return message
@@ -172,5 +173,19 @@ router.route('/:author/:permlink/comments').get(validate(single), controller.get
  * @apiError (NotFound 404) NotFound Permlink of the post cannot be found in the database.
  */
 router.route('/:author/:permlink/votes').get(validate(single), controller.getVotes);
+
+/**
+ * @api {put} v1/posts/update Update tags
+ * @apiDescription Update tags of a post
+ * @apiVersion 1.0.0
+ * @apiName updateTags
+ * @apiGroup Posts
+ * @apiPermission Logged users + Owners
+ *
+ * @apiHeader  {String}   access_token      SC2 User's access token
+ * @apiHeader  {String}   permlink          Permlink of the post
+ * @apiHeader  {Array}    tags              Tags of the post
+ */
+router.route('/update').put(validate(update), sc2Middleware, controller.updateTags);
 
 module.exports = router;

--- a/src/api/validations/post.validation.js
+++ b/src/api/validations/post.validation.js
@@ -9,7 +9,14 @@ module.exports = {
       category: Joi.string().required().max(25),
     },
   },
-
+  // PUT /v1/posts/update
+  update: {
+    body: {
+      access_token: Joi.string().min(6).max(512).required(),
+      permlink: Joi.string().required(),
+      tags: Joi.array().required(),
+    },
+  },
   // GET /v1/posts/:author/:permlink
   single: {
     param: {

--- a/src/api/validations/stats.validation.js
+++ b/src/api/validations/stats.validation.js
@@ -9,6 +9,7 @@ module.exports = {
   posts: {
     query: {
       username: Joi.string(),
+      author: Joi.string(),
       limit: Joi.number(),
       skip: Joi.number(),
     },

--- a/src/config/remarkable.js
+++ b/src/config/remarkable.js
@@ -1,0 +1,9 @@
+const Remarkable = require('remarkable');
+
+// Remarkable configuration
+module.exports = new Remarkable({
+  html: true,
+  breaks: true,
+  linkify: false,
+  typographer: false, // https://github.com/jonschlinkert/remarkable/issues/142#issuecomment-221546793
+});


### PR DESCRIPTION
Changes done:

- Endpoint to edit post's tags: PUT v1/posts/update
- Export remarkable plugin from different file to avoid initializing the same configuration all the time
- Truncate description field for v1/stats/... endpoints
- Add isVoted field to v1/stats/... endpoints
- Refactor stats params: now to get posts by author, need to use author param instead of username. Username param will be used to check if the current user has voted the post.