### PR TITLE
Removed job cancelation for delegators bot

### DIFF
--- a/src/api/bots/delegators.bot.js
+++ b/src/api/bots/delegators.bot.js
@@ -50,12 +50,8 @@ exports.startTokenDistribution = async (schedule) => {
 
       await utils.addKntToDelegator(delegator.user, kntRewards);
     }
-
-    // Cancel the job to allow the other job to start.
-    schedule.cancel();
   } catch (err) {
     logger.error(err);
-    schedule.cancel();
   }
 };
 


### PR DESCRIPTION
Removed job cancelation for delegators bot since this job is recurrent and not manual scheduling is needed.