### PR TITLE
Update createPostQueue method to use category key

### DIFF
--- a/src/api/controllers/moderation.controller.js
+++ b/src/api/controllers/moderation.controller.js
@@ -52,7 +52,7 @@ const createUser = async (username, next) => {
  */
 const createQueuePost = async (post, score) => {
   try {
-    const category = await Category.findOne({ name: post.category });
+    const category = await Category.findOne({ key: post.category });
     const weight = (score * category.scoreCap) / 100;
 
     const queuePost = new BotQueue({


### PR DESCRIPTION
When creating a post, the key is the one saved into the database instead of the actual name (as intended).

To create the post queue object, the category was queried using its name instead of the key causing the undefined error.